### PR TITLE
Ci/update-formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,3 +123,11 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Homebrew tap
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          repository: theburrowhub/homebrew-tap
+          event-type: update-formula
+          client-payload: '{"formula": "cherry-go", "version": "${{ needs.version-bump.outputs.new_tag }}"}'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,22 @@ A command-line tool for partial versioning of files from other Git repositories.
 
 Cherry-go provides an intelligent installation script that automatically detects whether you're installing from a local repository or downloading from GitHub releases.
 
-### Remote Installation (Recommended)
+### Homebrew (macOS/Linux)
+
+Install cherry-go using [Homebrew](https://brew.sh/):
+
+```bash
+brew tap theburrowhub/tap
+brew install theburrowhub/tap/cherry-go
+```
+
+Or in a single command:
+
+```bash
+brew install theburrowhub/tap/cherry-go
+```
+
+### Remote Installation
 
 Install the latest release directly from GitHub:
 
@@ -108,6 +123,10 @@ go install github.com/theburrowhub/cherry-go@latest
 ### Uninstallation
 
 ```bash
+# Using Homebrew
+brew uninstall cherry-go
+brew untap theburrowhub/tap  # Optional: remove the tap
+
 # Remove local installation
 ./scripts/uninstall.sh
 


### PR DESCRIPTION
- Added a new section for installing cherry-go via Homebrew on macOS/Linux.
- Included commands for both single and multi-line installation.
- Updated uninstallation instructions to reflect Homebrew usage.